### PR TITLE
Update docoumentdb dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "bson": "^0.2.16",
-    "documentdb": "^0.9.1",
+    "documentdb": "^1.7.0",
     "hooks": "^0.3.2",
     "sliced": "0.0.5",
     "underscore": "^1.7.0",


### PR DESCRIPTION
Updated the documentdb package to the most recent version.

Collections created using the new documentdb api cause the old version to fail on connection.
